### PR TITLE
Generating a valid metadata xml

### DIFF
--- a/iDPEntityDescriptor.go
+++ b/iDPEntityDescriptor.go
@@ -15,14 +15,16 @@ func (s *ServiceProviderSettings) GetEntityDescriptor() (string, error) {
 		MD:       "urn:oasis:names:tc:SAML:2.0:metadata",
 		EntityId: s.AssertionConsumerServiceURL,
 
-		Extensions: Extensions{
-			XMLName: xml.Name{
-				Local: "md:Extensions",
-			},
-			Alg:    "urn:oasis:names:tc:SAML:metadata:algsupport",
-			MDAttr: "urn:oasis:names:tc:SAML:metadata:attribute",
-			MDRPI:  "urn:oasis:names:tc:SAML:metadata:rpi",
-		},
+		Extensions: nil,
+		/* Currently disabled. When enabling make sure the element inside has a non-saml namespace
+		Extensions: &Extensions{
+			XMLName = xml.Name{
+			Local: "md:Extensions",
+		}
+			Alg =  "urn:oasis:names:tc:SAML:metadata:algsupport"
+			MDAttr = "urn:oasis:names:tc:SAML:metadata:attribute"
+			MDRPI = "urn:oasis:names:tc:SAML:metadata:rpi"
+		}*/
 		SPSSODescriptor: SPSSODescriptor{
 			ProtocolSupportEnumeration: "urn:oasis:names:tc:SAML:2.0:protocol",
 			SigningKeyDescriptor: KeyDescriptor{

--- a/types.go
+++ b/types.go
@@ -127,7 +127,7 @@ type EntityDescriptor struct {
 	MD       string `xml:"xmlns:md,attr"`
 	EntityId string `xml:"entityID,attr"`
 
-	Extensions      Extensions      `xml:"Extensions"`
+	Extensions      *Extensions      `xml:"Extensions,omitempty"`
 	SPSSODescriptor SPSSODescriptor `xml:"SPSSODescriptor"`
 }
 
@@ -137,7 +137,7 @@ type Extensions struct {
 	MDAttr  string `xml:"xmlns:mdattr,attr"`
 	MDRPI   string `xml:"xmlns:mdrpi,attr"`
 
-	EntityAttributes *string `xml:"EntityAttributes"`
+	EntityAttributes string `xml:"EntityAttributes"`
 }
 
 type SSODescriptor struct {

--- a/types.go
+++ b/types.go
@@ -137,7 +137,7 @@ type Extensions struct {
 	MDAttr  string `xml:"xmlns:mdattr,attr"`
 	MDRPI   string `xml:"xmlns:mdrpi,attr"`
 
-	EntityAttributes string `xml:"EntityAttributes"`
+	EntityAttributes *string `xml:"EntityAttributes"`
 }
 
 type SSODescriptor struct {


### PR DESCRIPTION
EntityAttribute is now a pointer to a string so in the event of an empty element it will not go into the metadata xml, possibly creating problems in validation