### PR TITLE
remove innerxml tag from Issuer.Url field

### DIFF
--- a/types.go
+++ b/types.go
@@ -26,7 +26,7 @@ type AuthnRequest struct {
 type Issuer struct {
 	XMLName xml.Name
 	SAML    string `xml:"xmlns:saml,attr,omitempty"`
-	Url     string `xml:",innerxml"`
+	Url     string 
 }
 
 type NameIDPolicy struct {


### PR DESCRIPTION
currently, metadata URL with special characters (e.g. &) will corrupt the xml as fields with "innexml" tag are not escaped accordingly to the xml.