### PR TITLE
add `xml:",chardata"` to Url field 

### DIFF
--- a/types.go
+++ b/types.go
@@ -26,7 +26,7 @@ type AuthnRequest struct {
 type Issuer struct {
 	XMLName xml.Name
 	SAML    string `xml:"xmlns:saml,attr,omitempty"`
-	Url     string 
+	Url     string `xml:",chardata"`
 }
 
 type NameIDPolicy struct {


### PR DESCRIPTION
add `xml:",chardata"` to Url field to avoid creating element in issuer and still be able to marshal the Url