### PR TITLE
Granular control over response validation method

### DIFF
--- a/authnresponse.go
+++ b/authnresponse.go
@@ -4,8 +4,9 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"errors"
-	"github.com/dorsha/go-saml/util"
 	"time"
+
+	"github.com/dorsha/go-saml/util"
 )
 
 func ParseCompressedEncodedResponse(b64ResponseXML string) (*Response, error) {
@@ -315,7 +316,7 @@ func (r *Response) AddAttribute(name, value string) {
 			Type:  "xs:string",
 			Value: value,
 		},
-	 	},
+		},
 	})
 }
 
@@ -369,4 +370,3 @@ func (r *Response) GetAttribute(name string) []string {
 	}
 	return values
 }
-

--- a/authnresponse.go
+++ b/authnresponse.go
@@ -4,9 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"errors"
-	"time"
-
 	"github.com/dorsha/go-saml/util"
+	"time"
 )
 
 func ParseCompressedEncodedResponse(b64ResponseXML string) (*Response, error) {
@@ -47,7 +46,7 @@ func ParseDecodedResponse(responseXML []byte) (*Response, error) {
 	return &response, nil
 }
 
-func (r *Response) Validate(s *ServiceProviderSettings) error {
+func (r *Response) Validate(signed bool, assertionConsumerService, publicCertPath string, timeToValidate time.Time) error {
 	if r.Version != "2.0" {
 		return errors.New("unsupported SAML Version")
 	}
@@ -64,20 +63,20 @@ func (r *Response) Validate(s *ServiceProviderSettings) error {
 		return errors.New("no signature")
 	}
 
-	if len(r.Destination) > 0 && r.Destination != s.AssertionConsumerServiceURL {
-		return errors.New("destination mismath expected: " + s.AssertionConsumerServiceURL + " not " + r.Destination)
+	if len(r.Destination) > 0 && r.Destination != assertionConsumerService {
+		return errors.New("destination mismath expected: " + assertionConsumerService + " not " + r.Destination)
 	}
 
 	if r.Assertion.Subject.SubjectConfirmation.Method != "urn:oasis:names:tc:SAML:2.0:cm:bearer" {
 		return errors.New("assertion method exception")
 	}
 
-	if r.Assertion.Subject.SubjectConfirmation.SubjectConfirmationData.Recipient != s.AssertionConsumerServiceURL {
-		return errors.New("subject recipient mismatch, expected: " + s.AssertionConsumerServiceURL + " not " + r.Assertion.Subject.SubjectConfirmation.SubjectConfirmationData.Recipient)
+	if r.Assertion.Subject.SubjectConfirmation.SubjectConfirmationData.Recipient != assertionConsumerService {
+		return errors.New("subject recipient mismatch, expected: " + assertionConsumerService + " not " + r.Assertion.Subject.SubjectConfirmation.SubjectConfirmationData.Recipient)
 	}
 
-	if s.SPSignRequest {
-		err := r.VerifySignature(s.IDPPublicCertPath)
+	if signed {
+		err := r.VerifySignature(publicCertPath)
 		if err != nil {
 			return err
 		}
@@ -89,7 +88,7 @@ func (r *Response) Validate(s *ServiceProviderSettings) error {
 	if e != nil {
 		return e
 	}
-	if notOnOrAfter.Before(time.Now()) {
+	if notOnOrAfter.Before(timeToValidate) {
 		return errors.New("assertion has expired on: " + expires)
 	}
 

--- a/authnresponse.go
+++ b/authnresponse.go
@@ -47,7 +47,11 @@ func ParseDecodedResponse(responseXML []byte) (*Response, error) {
 	return &response, nil
 }
 
-func (r *Response) Validate(signed bool, assertionConsumerService, publicCertPath string, timeToValidate time.Time) error {
+func (r *Response) Validate(s *ServiceProviderSettings) error {
+	return r.ValidateWithoutSP(s.SPSignRequest,s.AssertionConsumerServiceURL, s.IDPPublicCertPath, time.Now())
+}
+
+func (r *Response) ValidateWithoutSP(signed bool, assertionConsumerService, publicCertPath string, timeToValidate time.Time) error {
 	if r.Version != "2.0" {
 		return errors.New("unsupported SAML Version")
 	}

--- a/authnresponse.go
+++ b/authnresponse.go
@@ -59,7 +59,7 @@ func (r *Response) Validate(signed bool, assertionConsumerService, publicCertPat
 		return errors.New("no Assertions")
 	}
 
-	if s.SPSignRequest && len(r.Signature.SignatureValue.Value) == 0 {
+	if signed && len(r.Signature.SignatureValue.Value) == 0 {
 		return errors.New("no signature")
 	}
 


### PR DESCRIPTION
For our uses, we now need a way to validate a response without an SP struct available.
Instead, we would like to validate against given values.

This will enable more flexibility in usage.